### PR TITLE
[REVIEW] Add deprecation warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,23 @@
 Dask-XGBoost
 ============
 
+Deprecation warning!
+--------------------
+
+*dask-xgboost is now deprecated*. As of release 1.0, XGBoost provides a
+native Dask API:
+https://xgboost.readthedocs.io/en/latest/tutorials/dask.html
+
+The native XGBoost API has all of the functionality of dask-xgboost,
+combined with an updated, clean API and much more extensive
+testing. All users are encouraged to switch to the native API. See
+also this blog post for an overview:
+https://medium.com/rapids-ai/a-new-official-dask-api-for-xgboost-e8b10f3d1eb7
+
+
+Overview
+--------
+
 Distributed training with XGBoost and Dask.distributed
 
 This repository enables you to perform distributed training with XGBoost on


### PR DESCRIPTION
Explain in the readme that this library is now deprecated. Otherwise, no functional change.
The native Dask XGBoost API should replace this library for all users, so let's point them to the new API here as well.